### PR TITLE
Ai scroller fixes

### DIFF
--- a/src/lib/Scroller/Background.svelte
+++ b/src/lib/Scroller/Background.svelte
@@ -1,38 +1,64 @@
 <script>
+  import marked from 'marked';
+
   export let index;
   export let steps = [];
   export let preload = 1;
   export let stackBackground = 'true';
+  export let embedded;
 </script>
 
-{#each steps as step, i}
-  <!-- Load the step(s) before and after the active one, only -->
-  {#if preload === 0 || (i >= index - preload && i <= index + preload)}
-    {#if stackBackground === 'true'}
-      <div
-        class="step-background step-{i + 1}"
-        class:visible="{i <= index}"
-        class:hidden="{i > index}"
-      >
-        <svelte:component
-          this="{step.background}"
-          {...step.backgroundProps || {}}
-        />
-      </div>
-    {:else}
-      <div
-        class="step-background step-{i + 1}"
-        class:visible="{i === index}"
-        class:hidden="{i !== index}"
-      >
-        <svelte:component
-          this="{step.background}"
-          {...step.backgroundProps || {}}
-        />
-      </div>
+{#if !embedded}
+  {#each steps as step, i}
+    <!-- Load the step(s) before and after the active one, only -->
+    {#if preload === 0 || (i >= index - preload && i <= index + preload)}
+      {#if stackBackground === 'true'}
+        <div
+          class="step-background step-{i + 1}"
+          class:visible="{i <= index}"
+          class:hidden="{i > index}"
+        >
+          <svelte:component
+            this="{step.background}"
+            {...step.backgroundProps || {}}
+          />
+        </div>
+      {:else}
+        <div
+          class="step-background step-{i + 1}"
+          class:visible="{i === index}"
+          class:hidden="{i !== index}"
+        >
+          <svelte:component
+            this="{step.background}"
+            {...step.backgroundProps || {}}
+          />
+        </div>
+      {/if}
     {/if}
-  {/if}
-{/each}
+  {/each}
+{:else}
+  {#each steps as step, i}
+    <!-- Foreground text above each graphic -->
+    <div class="stacked-foreground step-{i + 1}">
+      {#if typeof step.foreground === 'string'}
+        {@html marked(step.foreground)}
+      {:else}
+        <svelte:component
+          this="{step.foreground}"
+          {...step.foregroundProps || {}}
+        />
+      {/if}
+    </div>
+    <!-- Load all background graphics, stacked -->
+    <div class="stacked-background step-{i + 1}">
+      <svelte:component
+        this="{step.background}"
+        {...step.backgroundProps || {}}
+      />
+    </div>
+  {/each}
+{/if}
 
 <style lang="scss">
   .step-background {

--- a/src/lib/Scroller/Background.svelte
+++ b/src/lib/Scroller/Background.svelte
@@ -1,64 +1,25 @@
 <script>
-  import marked from 'marked';
-
   export let index;
   export let steps = [];
   export let preload = 1;
-  export let stackBackground = 'true';
-  export let embedded;
+  export let stackBackground = true;
 </script>
 
-{#if !embedded}
-  {#each steps as step, i}
-    <!-- Load the step(s) before and after the active one, only -->
-    {#if preload === 0 || (i >= index - preload && i <= index + preload)}
-      {#if stackBackground === 'true'}
-        <div
-          class="step-background step-{i + 1}"
-          class:visible="{i <= index}"
-          class:hidden="{i > index}"
-        >
-          <svelte:component
-            this="{step.background}"
-            {...step.backgroundProps || {}}
-          />
-        </div>
-      {:else}
-        <div
-          class="step-background step-{i + 1}"
-          class:visible="{i === index}"
-          class:hidden="{i !== index}"
-        >
-          <svelte:component
-            this="{step.background}"
-            {...step.backgroundProps || {}}
-          />
-        </div>
-      {/if}
-    {/if}
-  {/each}
-{:else}
-  {#each steps as step, i}
-    <!-- Foreground text above each graphic -->
-    <div class="stacked-foreground step-{i + 1}">
-      {#if typeof step.foreground === 'string'}
-        {@html marked(step.foreground)}
-      {:else}
-        <svelte:component
-          this="{step.foreground}"
-          {...step.foregroundProps || {}}
-        />
-      {/if}
-    </div>
-    <!-- Load all background graphics, stacked -->
-    <div class="stacked-background step-{i + 1}">
+{#each steps as step, i}
+  <!-- Load the step(s) before and after the active one, only -->
+  {#if preload === 0 || (i >= index - preload && i <= index + preload)}
+    <div
+      class="step-background step-{i + 1}"
+      class:visible="{stackBackground ? i <= index : i === index}"
+      class:hidden="{stackBackground ? i > index : i !== index}"
+    >
       <svelte:component
         this="{step.background}"
         {...step.backgroundProps || {}}
       />
     </div>
-  {/each}
-{/if}
+  {/if}
+{/each}
 
 <style lang="scss">
   .step-background {

--- a/src/lib/Scroller/Background.svelte
+++ b/src/lib/Scroller/Background.svelte
@@ -2,18 +2,35 @@
   export let index;
   export let steps = [];
   export let preload = 1;
+  export let stackBackground = 'true';
 </script>
 
 {#each steps as step, i}
   <!-- Load the step(s) before and after the active one, only -->
   {#if preload === 0 || (i >= index - preload && i <= index + preload)}
-    <div
-      class="step-background step-{i + 1}"
-      class:visible="{i <= index}"
-      class:hidden="{i > index}"
-    >
-      <svelte:component this="{step.background}" {...(step.backgroundProps || {})} />
-    </div>
+    {#if stackBackground === 'true'}
+      <div
+        class="step-background step-{i + 1}"
+        class:visible="{i <= index}"
+        class:hidden="{i > index}"
+      >
+        <svelte:component
+          this="{step.background}"
+          {...step.backgroundProps || {}}
+        />
+      </div>
+    {:else}
+      <div
+        class="step-background step-{i + 1}"
+        class:visible="{i === index}"
+        class:hidden="{i !== index}"
+      >
+        <svelte:component
+          this="{step.background}"
+          {...step.backgroundProps || {}}
+        />
+      </div>
+    {/if}
   {/if}
 {/each}
 

--- a/src/lib/Scroller/Embedded/Background.svelte
+++ b/src/lib/Scroller/Embedded/Background.svelte
@@ -1,0 +1,14 @@
+<script>
+  export let step;
+  export let backgroundSize;
+  export let index;
+</script>
+
+<section class="background-container graphic {backgroundSize}" step="{index + 1}">
+  <div class="embedded-background step-{index + 1}">
+    <svelte:component
+      this="{step.background}"
+      {...step.backgroundProps || {}}
+    />
+  </div>
+</section>

--- a/src/lib/Scroller/Embedded/Foreground.svelte
+++ b/src/lib/Scroller/Embedded/Foreground.svelte
@@ -1,0 +1,31 @@
+<script>
+  export let step;
+  export let index;
+
+  import marked from 'marked';
+</script>
+
+{#if (step.foreground === '' || !step.foreground)}
+  <!-- Empty foreground -->
+  <div class="empty-step-foreground step-{index + 1}"></div>
+{:else if typeof step.foreground === 'string'}
+  <section class='body-text' step="{index + 1}">
+    <div class="embedded-foreground step-{index + 1}">
+      {@html marked(step.foreground)}
+    </div>
+  </section>
+{:else}
+  <div class="embedded-foreground step-{index + 1}">
+    <svelte:component
+      this="{step.foreground}"
+      {...step.foregroundProps || {}}
+    />
+  </div>
+{/if}
+
+<!-- svelte-ignore css-unused-selector -->
+<style lang="scss">
+  div.embedded-foreground :global(p:last-child) {
+    margin-bottom: 0;
+  }
+</style>

--- a/src/lib/Scroller/Embedded/index.svelte
+++ b/src/lib/Scroller/Embedded/index.svelte
@@ -1,0 +1,21 @@
+<script>
+  export let steps;
+  // fb (foreground then background) or bf (background then foreground)
+  export let embeddedLayout = 'fb';
+  export let backgroundSize;
+
+  import Background from './Background.svelte';
+  import Foreground from './Foreground.svelte';
+</script>
+
+{#each steps as step, index}
+  <!-- Background first -->
+  {#if embeddedLayout === 'bf'}
+    <Background {step} {index} {backgroundSize} />
+    <Foreground {step} {index} />
+  <!-- Foreground first, default -->
+  {:else}
+    <Foreground {step} {index} />
+    <Background {step} {index} {backgroundSize} />
+  {/if}
+{/each}

--- a/src/lib/Scroller/Foreground.svelte
+++ b/src/lib/Scroller/Foreground.svelte
@@ -1,12 +1,13 @@
 <script>
-  export let steps;
+  export let steps = [];
   import marked from 'marked';
 </script>
 
 {#each steps as step, i}
   <section class="step-foreground-container">
-    {#if step.foreground === '' || !step.foreground}
-      <!-- No blurb -->
+    {#if (step.foreground === '' || !step.foreground)}
+      <!-- Empty foreground -->
+      <div class="empty-step-foreground step-{i + 1}"></div>
     {:else}
       <div class="step-foreground step-{i + 1}">
         {#if typeof step.foreground === 'string'}

--- a/src/lib/Scroller/Foreground.svelte
+++ b/src/lib/Scroller/Foreground.svelte
@@ -1,18 +1,24 @@
 <script>
   export let steps;
-
   import marked from 'marked';
 </script>
 
 {#each steps as step, i}
-  <section class='step-foreground-container'>
-    <div class="step-foreground step-{i + 1}">
-      {#if typeof step.foreground === 'string'}
-        {@html marked(step.foreground)}  
-      {:else}
-        <svelte:component this="{step.foreground}" {...(step.foregroundProps || {})} />
-      {/if}
-    </div>
+  <section class="step-foreground-container">
+    {#if step.foreground === '' || !step.foreground}
+      <!-- No blurb -->
+    {:else}
+      <div class="step-foreground step-{i + 1}">
+        {#if typeof step.foreground === 'string'}
+          {@html marked(step.foreground)}
+        {:else}
+          <svelte:component
+            this="{step.foreground}"
+            {...step.foregroundProps || {}}
+          />
+        {/if}
+      </div>
+    {/if}
   </section>
 {/each}
 
@@ -26,17 +32,14 @@
     align-items: center;
     justify-content: center;
     margin-bottom: 5rem;
-
-    .step-foreground {
-      max-width: 550px;
-      width: 100%;
-      padding: 1.2rem 30px;
-      background: rgba(255, 255, 255, 0.8);
-      :global {
-        p:last-child {
-          margin-bottom: 0;
-        }
-      }
-    }
+  }
+  section .step-foreground {
+    max-width: 550px;
+    width: 100%;
+    padding: 1.2rem 30px;
+    background: rgba(255, 255, 255, 0.8);
+  }
+  section .step-foreground :global(p:last-child) {
+    margin-bottom: 0;
   }
 </style>

--- a/src/lib/Scroller/docs.svx
+++ b/src/lib/Scroller/docs.svx
@@ -25,9 +25,9 @@ slug: scroller
   ];
 
   const ai2svelteSteps = [
-    { background: 'ai-scroller-1', backgroundProps: { assets }, foreground: '#### Step 1\n\nLorem ipsum' },
-    { background: 'ai-scroller-2', backgroundProps: { assets }, foreground: '#### Step 2\n\nLorem ipsum' },
-    { background: 'ai-scroller-3', backgroundProps: { assets }, foreground: '#### Step 3\n\nLorem ipsum' },
+    { background: 'ai-scroller-1', foreground: '#### Step 1\n\nLorem ipsum' },
+    { background: 'ai-scroller-2', foreground: '#### Step 2\n\nLorem ipsum' },
+    { background: 'ai-scroller-3', foreground: '#### Step 3\n\nLorem ipsum' },
   ];
 
   const fetchComponent = async(componentName) => {
@@ -62,10 +62,11 @@ Easy scrolly-telling with layout options, based on [svelte-scroller](https://git
 
 - Adjusts the size of the background graphic by passing a class name corresponding to one of our well widths: `normal`, `wide`, `wider`, `widest` or `fluid`.
 
-
 `stackBackground`
 
-- Determines whether graphics will stack. Can be `true` or `false`. If true, the background graphics will stack and graphics from previous steps will remain visible. If false, only the graphic from the current step will show and graphics from previous steps are hidden.
+- Determines whether previous background step graphics will stack below current one.
+- `true` _default_ Background graphics from previous steps will remain visible below active one, allowing you to stack graphics with transparent backgrounds.
+- `false` Only the background graphic from the current step will show and backgrounds from previous steps are hidden.
 
 </section>
 
@@ -159,7 +160,6 @@ Both text and graphic will revert to the middle when the window drops below 1200
     foregroundPosition='right opposite'
     backgroundSize='normal'
     id='example2'
-    
   />
 </DemoContainer>
 
@@ -195,7 +195,7 @@ Pass a component to `foreground` and use `backgroundProps` and `foregroundProps`
   ];
 </script>
 
-<Scroller steps="{steps}" backgroundSize="widest"/>
+<Scroller steps="{steps}" backgroundSize="widest" />
 ```
 
 <DemoContainer fluid={true}>
@@ -203,7 +203,6 @@ Pass a component to `foreground` and use `backgroundProps` and `foregroundProps`
     steps={basicStepsComponent}
     backgroundSize="widest"
     id='example3'
-    
   />
 </DemoContainer>
 
@@ -239,7 +238,6 @@ Add an ID to your scroller and use SCSS `:global` rules to override any styles.
     steps={basicSteps}
     backgroundSize="widest"
     id='scroller-example-4'
-    
   />
 </DemoContainer>
 
@@ -291,7 +289,7 @@ Lorem ipsum...
   import { Scroller } from '@reuters-graphics/graphics-svelte-components';
 
   const fetchComponent = async (componentName) => {
-    return (await import(`./ai2html/${componentName}.svelte`)).default;
+    return (await import(`./ai2svelte/${componentName}.svelte`)).default;
   };
 
   const makeSteps = async (steps) => {
@@ -338,28 +336,44 @@ This pattern comes with some restrictions, though. Be sure your `fetchComponent`
       steps={steps}
       backgroundSize="fluid"
       id='example-5'
-      
     />
   {/await}
 </DemoContainer>
 
 <section>
 
-This component also automatically creates a stacked, embed version of the scroll section. The text goes on top of the graphic by default. 
+This component can also unravel the scrolling experience into a flat, linear layout. Use this when the graphic will be embedded in an iframe.
+
+`embedded`
+
+- Setting to `true` will unroll the scroll experience into a flat layout. `true` will also cause the `foregroundPosition` prop to be ignored. (Use global SCSS to adjust the style of foreground text.)
+
+`embeddedLayout`
+
+- `fb` (default) will layout the foreground before the background in each step.
+- `bf` will lead with the background in each step.
+
 </section>
+
+```svelte
+<Scroller
+  steps="{steps}"
+  backgroundSize="fluid"
+  embedded="{true}"
+  embeddedLayout="fb"
+/>
+```
 
 <DemoContainer fluid={true}>
   {#await makeSteps(ai2svelteSteps) then steps}
     <Scroller
       steps={steps}
-      backgroundSize="wide"
-      id='example1'
+      backgroundSize="fluid"
+      id='example6'
       embedded=true
     />
   {/await}
 </DemoContainer>
-
-
 
 <style lang="scss">
   :global {

--- a/src/lib/Scroller/docs.svx
+++ b/src/lib/Scroller/docs.svx
@@ -57,9 +57,13 @@ Easy scrolly-telling with layout options, based on [svelte-scroller](https://git
 - `foreground` Either a markdown string or a foreground component **REQUIRED**
 - `foregroundProps` An object of props given to foreground component
 
-`backgroundSize`
+`stackBackground`
 
 - Adjusts the size of the background graphic by passing a class name corresponding to one of our well widths: `normal`, `wide`, `wider`, `widest` or `fluid`.
+
+`backgroundSize`
+
+- Determines whether graphics will stack or not. Can be true or false. If true, the background graphics will stack and graphics from previous steps will remain visible. If false, only the graphic from the current step will show and graphics from previous steps are hidden.
 
 </section>
 

--- a/src/lib/Scroller/docs.svx
+++ b/src/lib/Scroller/docs.svx
@@ -10,6 +10,7 @@ slug: scroller
   import Clicker from './demos/basic/_Clicker.svelte';
 
   import BasicStep from './demos/basic/_Step.svelte';
+  import { assets } from '$app/paths';
 
   const basicSteps = [
     { background: BasicStep, backgroundProps: { colour: 'red' }, foreground: '#### Step 1\n\nLorem ipsum red' },
@@ -24,9 +25,9 @@ slug: scroller
   ];
 
   const ai2svelteSteps = [
-    { background: 'ai-scroller-1', foreground: '#### Step 1\n\nLorem ipsum' },
-    { background: 'ai-scroller-2', foreground: '#### Step 2\n\nLorem ipsum' },
-    { background: 'ai-scroller-3', foreground: '#### Step 3\n\nLorem ipsum' },
+    { background: 'ai-scroller-1', backgroundProps: { assets }, foreground: '#### Step 1\n\nLorem ipsum' },
+    { background: 'ai-scroller-2', backgroundProps: { assets }, foreground: '#### Step 2\n\nLorem ipsum' },
+    { background: 'ai-scroller-3', backgroundProps: { assets }, foreground: '#### Step 3\n\nLorem ipsum' },
   ];
 
   const fetchComponent = async(componentName) => {
@@ -57,13 +58,14 @@ Easy scrolly-telling with layout options, based on [svelte-scroller](https://git
 - `foreground` Either a markdown string or a foreground component **REQUIRED**
 - `foregroundProps` An object of props given to foreground component
 
-`stackBackground`
+`backgroundSize`
 
 - Adjusts the size of the background graphic by passing a class name corresponding to one of our well widths: `normal`, `wide`, `wider`, `widest` or `fluid`.
 
-`backgroundSize`
 
-- Determines whether graphics will stack or not. Can be true or false. If true, the background graphics will stack and graphics from previous steps will remain visible. If false, only the graphic from the current step will show and graphics from previous steps are hidden.
+`stackBackground`
+
+- Determines whether graphics will stack. Can be `true` or `false`. If true, the background graphics will stack and graphics from previous steps will remain visible. If false, only the graphic from the current step will show and graphics from previous steps are hidden.
 
 </section>
 
@@ -157,6 +159,7 @@ Both text and graphic will revert to the middle when the window drops below 1200
     foregroundPosition='right opposite'
     backgroundSize='normal'
     id='example2'
+    
   />
 </DemoContainer>
 
@@ -192,7 +195,7 @@ Pass a component to `foreground` and use `backgroundProps` and `foregroundProps`
   ];
 </script>
 
-<Scroller steps="{steps}" backgroundSize="widest" />
+<Scroller steps="{steps}" backgroundSize="widest"/>
 ```
 
 <DemoContainer fluid={true}>
@@ -200,6 +203,7 @@ Pass a component to `foreground` and use `backgroundProps` and `foregroundProps`
     steps={basicStepsComponent}
     backgroundSize="widest"
     id='example3'
+    
   />
 </DemoContainer>
 
@@ -235,6 +239,7 @@ Add an ID to your scroller and use SCSS `:global` rules to override any styles.
     steps={basicSteps}
     backgroundSize="widest"
     id='scroller-example-4'
+    
   />
 </DemoContainer>
 
@@ -281,6 +286,7 @@ Lorem ipsum...
 ```svelte
 <!-- src/lib/Page.svelte -->
 <script>
+  import { assets } from '$app/paths';
   import content from '$locales/en/content.json';
   import { Scroller } from '@reuters-graphics/graphics-svelte-components';
 
@@ -294,6 +300,7 @@ Lorem ipsum...
       const background = await fetchComponent(step.Background);
       scrollerSteps.push({
         background,
+        backgroundProps: { assets },
         foreground: step.Foreground,
       });
     }
@@ -331,9 +338,28 @@ This pattern comes with some restrictions, though. Be sure your `fetchComponent`
       steps={steps}
       backgroundSize="fluid"
       id='example-5'
+      
     />
   {/await}
 </DemoContainer>
+
+<section>
+
+This component also automatically creates a stacked, embed version of the scroll section. The text goes on top of the graphic by default. 
+</section>
+
+<DemoContainer fluid={true}>
+  {#await makeSteps(ai2svelteSteps) then steps}
+    <Scroller
+      steps={steps}
+      backgroundSize="wide"
+      id='example1'
+      embedded=true
+    />
+  {/await}
+</DemoContainer>
+
+
 
 <style lang="scss">
   :global {

--- a/src/lib/Scroller/index.svelte
+++ b/src/lib/Scroller/index.svelte
@@ -3,6 +3,7 @@
   import Scroller from '@sveltejs/svelte-scroller';
   import Background from './Background.svelte';
   import Foreground from './Foreground.svelte';
+  import Embedded from './Embedded/index.svelte';
 
   export let id = '';
   export let steps = [];
@@ -10,10 +11,10 @@
   export let backgroundSize = 'fluid';
   // middle, left, right, left opposite or right opposite
   export let foregroundPosition = 'middle';
-  // true or false
-  export let stackBackground;
-  export let preload;
-  export let embedded;
+  export let stackBackground = true;
+  export let preload = 1;
+  export let embedded = false;
+  export let embeddedLayout = 'fb';
 
   // Passed to svelte-scroller
   export let threshold = 0.5;
@@ -35,7 +36,7 @@
       top="{top}"
       bottom="{bottom}"
       parallax="{parallax}"
-      query="{'section.step-foreground-container'}"
+      query="section.step-foreground-container"
     >
       <div
         slot="background"
@@ -53,7 +54,6 @@
               steps="{steps}"
               preload="{preload}"
               stackBackground="{stackBackground}"
-              embedded="{embedded}"
             />
           </section>
         </div>
@@ -65,21 +65,25 @@
     </Scroller>
   </section>
 {:else}
-  <Background
-    index="{index + 1}"
-    steps="{steps}"
-    preload="{preload}"
-    embedded="{embedded}"
-  />
+  <section class="scroller-container embedded" id="{id}">
+    <Embedded
+      steps="{steps}"
+      embeddedLayout="{embeddedLayout}"
+      backgroundSize="{backgroundSize}"
+    />
+  </section>
 {/if}
 
 <style lang="scss">
   .scroller-container {
     margin-top: 5rem;
     margin-bottom: 5rem;
-    width: calc(100vw - 15px);
+    width: 100vw;
     margin-left: -15px;
-    max-width: none;
+    max-width: initial;
+    &.embedded {
+      padding: 0 15px;
+    }
   }
 
   div.background {

--- a/src/lib/Scroller/index.svelte
+++ b/src/lib/Scroller/index.svelte
@@ -10,7 +10,9 @@
   export let backgroundSize = 'fluid';
   // middle, left, right, left opposite or right opposite
   export let foregroundPosition = 'middle';
-  export let preload = 1;
+  // true or false
+  export let stackBackground;
+  export let preload;
 
   // Passed to svelte-scroller
   export let threshold = 0.5;
@@ -22,16 +24,16 @@
   let offset, progress;
 </script>
 
-<section class="scroller-container fluid" id="{id}">
+<section class="scroller-container" id="{id}">
   <Scroller
     bind:index
     bind:offset
     bind:progress
-    threshold={threshold}
-    top={top}
-    bottom={bottom}
-    parallax={parallax}
-    query={'section.step-foreground-container'}
+    threshold="{threshold}"
+    top="{top}"
+    bottom="{bottom}"
+    parallax="{parallax}"
+    query="{'section.step-foreground-container'}"
   >
     <div
       slot="background"
@@ -44,7 +46,12 @@
           class="background-container graphic {backgroundSize}"
           step="{index + 1}"
         >
-          <Background index="{index}" steps="{steps}" preload="{preload}" />
+          <Background
+            index="{index}"
+            steps="{steps}"
+            preload="{preload}"
+            stackBackground="{stackBackground}"
+          />
         </section>
       </div>
     </div>
@@ -59,6 +66,9 @@
   .scroller-container {
     margin-top: 5rem;
     margin-bottom: 5rem;
+    width: calc(100vw - 15px);
+    margin-left: -15px;
+    max-width: none;
   }
 
   div.background {

--- a/src/lib/Scroller/index.svelte
+++ b/src/lib/Scroller/index.svelte
@@ -13,6 +13,7 @@
   // true or false
   export let stackBackground;
   export let preload;
+  export let embedded;
 
   // Passed to svelte-scroller
   export let threshold = 0.5;
@@ -24,43 +25,53 @@
   let offset, progress;
 </script>
 
-<section class="scroller-container" id="{id}">
-  <Scroller
-    bind:index
-    bind:offset
-    bind:progress
-    threshold="{threshold}"
-    top="{top}"
-    bottom="{bottom}"
-    parallax="{parallax}"
-    query="{'section.step-foreground-container'}"
-  >
-    <div
-      slot="background"
-      class="background"
-      class:right="{foregroundPosition === 'left opposite'}"
-      class:left="{foregroundPosition === 'right opposite'}"
+{#if !embedded}
+  <section class="scroller-container" id="{id}">
+    <Scroller
+      bind:index
+      bind:offset
+      bind:progress
+      threshold="{threshold}"
+      top="{top}"
+      bottom="{bottom}"
+      parallax="{parallax}"
+      query="{'section.step-foreground-container'}"
     >
-      <div class="scroller-graphic-well">
-        <section
-          class="background-container graphic {backgroundSize}"
-          step="{index + 1}"
-        >
-          <Background
-            index="{index}"
-            steps="{steps}"
-            preload="{preload}"
-            stackBackground="{stackBackground}"
-          />
-        </section>
+      <div
+        slot="background"
+        class="background"
+        class:right="{foregroundPosition === 'left opposite'}"
+        class:left="{foregroundPosition === 'right opposite'}"
+      >
+        <div class="scroller-graphic-well">
+          <section
+            class="background-container graphic {backgroundSize}"
+            step="{index + 1}"
+          >
+            <Background
+              index="{index}"
+              steps="{steps}"
+              preload="{preload}"
+              stackBackground="{stackBackground}"
+              embedded="{embedded}"
+            />
+          </section>
+        </div>
       </div>
-    </div>
 
-    <div slot="foreground" class="foreground {foregroundPosition}">
-      <Foreground steps="{steps}" />
-    </div>
-  </Scroller>
-</section>
+      <div slot="foreground" class="foreground {foregroundPosition}">
+        <Foreground steps="{steps}" />
+      </div>
+    </Scroller>
+  </section>
+{:else}
+  <Background
+    index="{index + 1}"
+    steps="{steps}"
+    preload="{preload}"
+    embedded="{embedded}"
+  />
+{/if}
 
 <style lang="scss">
   .scroller-container {


### PR DESCRIPTION
- Fixed background jolting on stick/unstick. Didn't have to use window innerWidth, which is great. Instead, I took out the `fluid` class and added these css to `.scroller-container`:
                            `width: calc(100vw - 15px); `
                            ` margin-left: -15px; `
                            ` max-width: none;`

- In `Foreground.svelte`, added an if/else check to see if `step.foreground` exists or is an empty string. Now there will be a blurb div only if `Foreground` is filled out in the google doc
- Changed `index.svelte` and `Background.svelte` to make an embed version. The embed version stacks graphics and text. Text goes above graphic by default. Added explanations on this to docs.
- Added `StackBackground` prop to Google doc. Added explanations on this to docs. We can now control whether to stack all background graphics or to hide previous slides. This prop is set to "true" by default.
- In `index.svelte`, changed `  export let preload = 1` to `  export let preload;`. Previously, this variable was set to `  export let preload = 1` in both `index.svelte` and in `Background.svelte`, which meant that if I wanted to set `preload=0`, I had to do it in two places. 