### PR TITLE
Width fix for .scoller-container

### DIFF
--- a/src/lib/Scroller/index.svelte
+++ b/src/lib/Scroller/index.svelte
@@ -78,7 +78,8 @@
   .scroller-container {
     margin-top: 5rem;
     margin-bottom: 5rem;
-    width: 100vw;
+    // width: 100vw;
+    width: calc(100% + 30px);
     margin-left: -15px;
     max-width: initial;
     &.embedded {


### PR DESCRIPTION
I think we should make `.scroller-container` width `calc(100%+30px)` instead of `width: 100vw`. I made a demo page using the latest version of svelte components library and the boilerplate, and without  `calc(100%+30px)`, the graphic width shrinks and expands a little when the background sticks/unsticks if the graphic width is not fluid. Pretty sure this happens because the `overflow: hidden` css we added gets rid of overflow but doesn't fix the width becoming bigger/smaller by 15px.

If `.scroller-container` has  `width: calc(100%+30px)`, the graphic doesn't move or shrink/expand on stick/unstick.