### PR TITLE
Small fix: moved step-{i + 1} class to <section>

### DIFF
--- a/src/lib/Ai2svelte/index.svelte
+++ b/src/lib/Ai2svelte/index.svelte
@@ -45,7 +45,7 @@
     width: 1px !important;
     height: 1px !important;
     padding: 0 !important;
-    margin: -1px !important; //Fix for https://github.com/twbs/bootstrap/issues/25686
+    margin: -1px !important; //wFix for https://github.com/twbs/bootstrap/issues/25686
     overflow: hidden !important;
     clip: rect(0, 0, 0, 0) !important;
     clip-path: polygon(0px 0px, 0px 0px, 0px 0px);

--- a/src/lib/Ai2svelte/index.svelte
+++ b/src/lib/Ai2svelte/index.svelte
@@ -45,7 +45,7 @@
     width: 1px !important;
     height: 1px !important;
     padding: 0 !important;
-    margin: -1px !important; //wFix for https://github.com/twbs/bootstrap/issues/25686
+    margin: -1px !important; // Fix for https://github.com/twbs/bootstrap/issues/25686
     overflow: hidden !important;
     clip: rect(0, 0, 0, 0) !important;
     clip-path: polygon(0px 0px, 0px 0px, 0px 0px);

--- a/src/lib/Scroller/Foreground.svelte
+++ b/src/lib/Scroller/Foreground.svelte
@@ -4,12 +4,12 @@
 </script>
 
 {#each steps as step, i}
-  <section class="step-foreground-container">
+  <section class="step-foreground-container step-{i + 1}">
     {#if step.foreground === '' || !step.foreground}
       <!-- Empty foreground -->
-      <div class="empty-step-foreground step-{i + 1}"></div>
+      <div class="empty-step-foreground"></div>
     {:else}
-      <div class="step-foreground step-{i + 1}">
+      <div class="step-foreground">
         {#if typeof step.foreground === 'string'}
           {@html marked.parse(step.foreground)}
         {:else}


### PR DESCRIPTION
### What's in this pull request

- [ ] 2 small nice-to-have fixes

### Description

- In `Foreground.svelte` for the Scroller component, moved the `step-{i + 1}` class to `<section class="step-foreground-container>` from `<div class="step-foreground">` so that it is easier to select the section using css

- There was a wrong "w" in the css portion of `Ai2svelte/index.svelte`, so I fixed the typo