### PR TITLE
make chart chatter respect the text well limits. closes #37

### DIFF
--- a/src/lib/Ai2svelte/docs.svx
+++ b/src/lib/Ai2svelte/docs.svx
@@ -127,6 +127,7 @@ Add additional chart chatter through slots.
 <Ai2svelte
   AiGraphic="{MyAiChart}"
   id="ai-map"
+  size="wide"
   ariaDescription="A map of Haiti shows the epicenter of an earthquake in the southwest of the country." 
 >
   <!-- Add a title and/or notes with slots -->
@@ -151,6 +152,7 @@ Add additional chart chatter through slots.
 <DemoContainer>
   <Ai2svelte AiGraphic="{AiChart}" id="ai-map"
    ariaHidden = {true}
+   size="wide"
   ariaDescription="A map of Haiti shows the epicenter of an earthquake in the southwest of the country." >
     <!-- Add a title and/or notes with slots -->
     <div slot="title" class="title">

--- a/src/lib/Ai2svelte/index.svelte
+++ b/src/lib/Ai2svelte/index.svelte
@@ -20,7 +20,9 @@
 <section class="ai2svelte-container graphic {size}" id="{id}">
   {#if (ariaHidden && (ariaDescription || $$slots.hidden)) || !ariaHidden}
     {#if $$slots.title}
-      <slot name="title" />
+      <div class="chatter-container">
+        <slot name="title" />
+      </div>
     {/if}
     {#if ariaDescription}
       <p class="visually-hidden">{ariaDescription}</p>
@@ -34,12 +36,18 @@
       <svelte:component this="{AiGraphic}" onAiMounted="{onAiMounted}" />
     </div>
     {#if $$slots.notes}
-      <slot name="notes" />
+      <div class="chatter-container">
+        <slot name="notes" />
+      </div>
     {/if}
   {/if}
 </section>
 
 <style lang="scss">
+  @import '~@reuters-graphics/style-theme-eisbaer/scss/components/containers/widths';
+  .chatter-container {
+    @extend .well;
+  }
   .visually-hidden {
     position: absolute !important;
     width: 1px !important;


### PR DESCRIPTION
### What's in this pull request

- [x] Bug fix
- [ ] New component/feature
- [ ] Documentation update
- [ ] Other

### Description

Limits chart chatter to text well dimensions, per #37.

### Before submitting, please check that you've

- [ ] Read our [contributing guide](https://github.com/reuters-graphics/graphics-svelte-components/blob/master/CONTRIBUTING.md) at some point
- [ ] Formatted you code correctly (i.e., prettier cleaned it up)
- [ ] Documented any new components or features
- [ ] Tagged an editor to review
