### PR TITLE
Update doc with location of the component

### DIFF
--- a/src/lib/SiteHeader/docs.svx
+++ b/src/lib/SiteHeader/docs.svx
@@ -15,6 +15,8 @@ slug: site-header
 
 Reuters dotcom site header, ported from [Raptor UI components](https://github.com/tr/rcom-arc_raptor-ui/tree/develop/packages/rcom-raptor-ui_common/src/components/site-header).
 
+The SiteHeader component is likely already included in your page. You can find it in `pages/index.svelte` in your project directory. This is where you should make any prop customizations.
+
 </section>
 
 ```svelte


### PR DESCRIPTION
Love this new component! At first, I added it to App.svelte because I wanted to customize the color. I ended up with two headers on my page since it's already being used in index.svelte. It took me a minute to figure out where it was already being imported. My thought is that by adding the location of the component to the docs, we can avoid the confusion I had.

### What's in this pull request
- Documentation update